### PR TITLE
treat http error and status code differently when getting archive link

### DIFF
--- a/github/repos_contents.go
+++ b/github/repos_contents.go
@@ -211,8 +211,11 @@ func (s *RepositoriesService) GetArchiveLink(owner, repo string, archiveformat a
 	} else {
 		resp, err = s.client.client.Transport.RoundTrip(req)
 	}
-	if err != nil || resp.StatusCode != http.StatusFound {
-		return nil, newResponse(resp), err
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode != http.StatusFound {
+		return nil, newResponse(resp), fmt.Errorf("Expected 302, received %v", resp.StatusCode)
 	}
 	parsedURL, err := url.Parse(resp.Header.Get("Location"))
 	return parsedURL, newResponse(resp), err


### PR DESCRIPTION
cc @robfig 

This was responsible for the sites-cog crash earlier.