### PR TITLE
make sure responses are fresh

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -161,6 +161,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 
 	req.Header.Add("Accept", mediaTypeV3)
 	req.Header.Add("User-Agent", c.UserAgent)
+	req.Header.Set("Cache-Control", "must-revalidate")
 	return req, nil
 }
 


### PR DESCRIPTION
currently if you push/delete tags from a repo and then query the list of refs, github returns stale data. setting the cache-control header to "must-revalidate" alleviates this. [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) is a list of other values we could set if we'd prefer no caching or something.